### PR TITLE
feat: add steam deck oled audio firmware and config

### DIFF
--- a/elements/gamerslop/valve-hw-audio.bst
+++ b/elements/gamerslop/valve-hw-audio.bst
@@ -1,17 +1,14 @@
 kind: manual
 
-# building firmware outselves isn't possible, some submodules required for building aren't accessible outside of steamos team
+# building firmware ourselves isn't possible, some submodules required for building aren't accessible outside of steamos team
 # at the very least they have prebuilt binaries right in git repo, thanks lol
 sources:
 - kind: git_repo
   url: github:evlaV/valve-hardware-audio-processing
+  track: main
   ref: 4117b4c0b971744c9cc63606b90175ee69ed4ed9
 
-build-depends:
-- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
-
 depends:
-- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - gnome-build-meta.bst:gnomeos-deps/alsa-ucm-conf.bst
 
 variables:

--- a/elements/gamerslop/valve-hw-audio.bst
+++ b/elements/gamerslop/valve-hw-audio.bst
@@ -1,0 +1,28 @@
+kind: manual
+
+# building firmware outselves isn't possible, some submodules required for building aren't accessible outside of steamos team
+# at the very least they have prebuilt binaries right in git repo, thanks lol
+sources:
+- kind: git_repo
+  url: github:evlaV/valve-hardware-audio-processing
+  ref: 4117b4c0b971744c9cc63606b90175ee69ed4ed9
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- gnome-build-meta.bst:gnomeos-deps/alsa-ucm-conf.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm0644 ./ucm2/conf.d/sof-nau8821-max/* -t "%{install-root}%{datadir}/alsa/ucm2/conf.d/sof-nau8821-max"
+
+    install -Dm0644 ./sof_fw/sof/* -t "%{install-root}%{prefix}/lib/firmware/amd/sof"
+    install -Dm0644 ./sof_fw/sof-tplg/* -t "%{install-root}%{prefix}/lib/firmware/amd/sof-tplg"
+  - |
+    %{install-extra}

--- a/elements/oci/jackrabbit/stack.bst
+++ b/elements/oci/jackrabbit/stack.bst
@@ -4,6 +4,7 @@ depends:
   - stacks/jackrabbit.bst
   - gamerslop/linux-ogc.bst
   - gamerslop/initramfs.bst
+  - gamerslop/valve-hw-audio.bst
   - gamerslop/xonedo-dkms.bst
   - gamerslop/xonedo-firmware.bst
 


### PR DESCRIPTION
Just tested it locally and it works. According to Archwiki that's the only things needs to be added to get audio working on Steam Deck OLED. To be honest not sure if it conflicts with anything else, it probably does not

https://wiki.archlinux.org/title/Steam_Deck#Audio