### PR TITLE
Merge testing into stable

### DIFF
--- a/elements/cli/brew.bst
+++ b/elements/cli/brew.bst
@@ -4,7 +4,7 @@ sources:
 - kind: docker
   url: ghcr:ublue-os/brew
   track: latest
-  ref: 735647b6cb3acbcba927e385d8d7abac0601485f31ca72b6aabc8c1a568b08ed
+  ref: 2c469e4b04a2d5d0f20ed61b909a3ee3f526842f05181997a5999cdacef03b14
 
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst

--- a/elements/cli/chezmoi.bst
+++ b/elements/cli/chezmoi.bst
@@ -7,22 +7,22 @@ sources:
 - kind: git_repo
   url: github:twpayne/chezmoi.git
   track: v*
-  ref: v2.72.0-0-gf81cb321789aa3df62871248f5e4d361a59e7cc1
+  ref: v2.72.1-0-gf901167e4685db90da56d6a2a19df642cb3e0247
 - kind: tar
   base-dir: "usr/bin"
   (?):
   - arch == "aarch64":
       url: github_files:twpayne/chezmoi/releases/download/v%{version}/chezmoi_%{version}_linux_arm64.apk
-      ref: cf14eb0c5125886301c0c9042d80cf1394dbc4c82d6c8f84c9ec866c3d5253fd
+      ref: 5ab01410b1645448e10500cf36b5f9d6c1725b97612675f6d93b11d75b365ec7
   - arch == "x86_64":
       url: github_files:twpayne/chezmoi/releases/download/v%{version}/chezmoi_%{version}_linux_amd64.apk
-      ref: b55c2dc66b8a1de99120c05cb1aa9e09ed93ba3eea628c2f3dc385f86b05132d
+      ref: 47719461fd04743b24bb8b5c3fac3f8668848349a7cad8aabfce2bcbe7c1ff91
 
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:
-  version: 2.72.0
+  version: 2.72.1
   strip-binaries: ""
 
 config:

--- a/elements/cli/fastfetch.bst
+++ b/elements/cli/fastfetch.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:fastfetch-cli/fastfetch.git
   track: "*"
-  ref: 2.67.1-0-g4dd2f2d34bf80f3e66b26d3869467de88ee1ca52
+  ref: 2.68.1-0-g1c1136ebd1e943d6d2ba7c204a11deee3e948dd8
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst

--- a/elements/core/bootc.bst
+++ b/elements/core/bootc.bst
@@ -7,6 +7,7 @@ sources:
   ref: v1.16.10-0-g3e76c16556c55e6d15d31bd47602b231e2131cb2
   exclude:
   - v1.16.7
+  - v1.16.11
 - kind: local
   path: files/bootc
 - kind: cargo2

--- a/elements/desktop/fonts/noto-fonts.bst
+++ b/elements/desktop/fonts/noto-fonts.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:notofonts/notofonts.github.io
   track: "noto-monthly-release-*"
-  ref: noto-monthly-release-2026.08.01-0-g113d8e66a13a47d514be6c07e616842258982f42
+  ref: noto-monthly-release-2026.09.01-0-g76fff9eee60dcef8381bfcae8d0b4311e2186e67
 - kind: local
   path: files/noto
 

--- a/elements/desktop/foot.bst
+++ b/elements/desktop/foot.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: codeberg:dnkl/foot.git
   track: "*"
-  ref: 1.27.0-0-gde998602dbc00c8862a6823d553cbb1df91c676d
+  ref: 1.28.0-0-gab33c9a19d626f8d0ac0bd1adfdba21946ada948
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/elements/desktop/xwayland-satellite.bst
+++ b/elements/desktop/xwayland-satellite.bst
@@ -1,0 +1,568 @@
+kind: cargo
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+- freedesktop-sdk.bst:components/cargo-c.bst
+- freedesktop-sdk.bst:components/pkg-config.bst
+- freedesktop-sdk.bst:components/rust.bst
+
+depends:
+- freedesktop-sdk.bst:components/fontconfig.bst
+- freedesktop-sdk.bst:components/xcb-util-cursor.bst
+- freedesktop-sdk.bst:components/xcb-util.bst
+- freedesktop-sdk.bst:components/xorg-lib-xcb.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+- kind: git_repo
+  url: github:Supreeeme/xwayland-satellite.git
+  # FIXME: enable track when upstream issue is fixed:
+  # https://github.com/Supreeeme/xwayland-satellite/issues/468
+  # track: v*
+  ref: v0.8.1-0-g536bd32efc935bf876d6de385ec18a1b715c9358
+- kind: cargo2
+  ref:
+  - kind: registry
+    name: ab_glyph
+    version: 0.2.32
+    sha: 01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2
+  - kind: registry
+    name: ab_glyph_rasterizer
+    version: 0.1.10
+    sha: 366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618
+  - kind: registry
+    name: adler2
+    version: 2.0.1
+    sha: 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa
+  - kind: registry
+    name: ahash
+    version: 0.8.12
+    sha: 5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75
+  - kind: registry
+    name: aho-corasick
+    version: 1.1.4
+    sha: ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301
+  - kind: registry
+    name: allocator-api2
+    version: 0.2.21
+    sha: 683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923
+  - kind: registry
+    name: anyhow
+    version: 1.0.100
+    sha: a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61
+  - kind: registry
+    name: arrayref
+    version: 0.3.9
+    sha: 76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb
+  - kind: registry
+    name: arrayvec
+    version: 0.7.6
+    sha: 7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50
+  - kind: registry
+    name: bindgen
+    version: 0.72.1
+    sha: 993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895
+  - kind: registry
+    name: bitflags
+    version: 1.3.2
+    sha: bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a
+  - kind: registry
+    name: bitflags
+    version: 2.10.0
+    sha: 812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3
+  - kind: registry
+    name: bytemuck
+    version: 1.24.0
+    sha: 1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4
+  - kind: registry
+    name: cc
+    version: 1.2.48
+    sha: c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a
+  - kind: registry
+    name: cexpr
+    version: 0.6.0
+    sha: 6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766
+  - kind: registry
+    name: cfg-if
+    version: 1.0.4
+    sha: 9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801
+  - kind: registry
+    name: clang-sys
+    version: 1.8.1
+    sha: 0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4
+  - kind: registry
+    name: crc32fast
+    version: 1.5.0
+    sha: 9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511
+  - kind: registry
+    name: cursor-icon
+    version: 1.2.0
+    sha: f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f
+  - kind: registry
+    name: darling
+    version: 0.20.11
+    sha: fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee
+  - kind: registry
+    name: darling_core
+    version: 0.20.11
+    sha: 0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e
+  - kind: registry
+    name: darling_macro
+    version: 0.20.11
+    sha: fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead
+  - kind: registry
+    name: deranged
+    version: 0.5.5
+    sha: ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587
+  - kind: registry
+    name: derive_builder
+    version: 0.20.2
+    sha: 507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947
+  - kind: registry
+    name: derive_builder_core
+    version: 0.20.2
+    sha: 2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8
+  - kind: registry
+    name: derive_builder_macro
+    version: 0.20.2
+    sha: ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c
+  - kind: registry
+    name: dlib
+    version: 0.5.2
+    sha: 330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412
+  - kind: registry
+    name: downcast-rs
+    version: 1.2.1
+    sha: 75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2
+  - kind: registry
+    name: either
+    version: 1.15.0
+    sha: 48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719
+  - kind: registry
+    name: env_logger
+    version: 0.10.2
+    sha: 4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580
+  - kind: registry
+    name: equivalent
+    version: 1.0.2
+    sha: 877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f
+  - kind: registry
+    name: errno
+    version: 0.3.14
+    sha: 39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb
+  - kind: registry
+    name: fdeflate
+    version: 0.3.7
+    sha: 1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c
+  - kind: registry
+    name: find-msvc-tools
+    version: 0.1.5
+    sha: 3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844
+  - kind: registry
+    name: flate2
+    version: 1.1.5
+    sha: bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb
+  - kind: registry
+    name: fnv
+    version: 1.0.7
+    sha: 3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1
+  - kind: registry
+    name: foldhash
+    version: 0.1.5
+    sha: d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2
+  - kind: registry
+    name: fontconfig
+    version: 0.10.0
+    sha: b19c4bca8c705ea23bfb3e3403a9e699344d1ee3205b631f03fe4dbf1e52429f
+  - kind: registry
+    name: fontdue
+    version: 0.9.3
+    sha: 2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b
+  - kind: registry
+    name: glob
+    version: 0.3.3
+    sha: 0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280
+  - kind: registry
+    name: hashbrown
+    version: 0.14.5
+    sha: e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1
+  - kind: registry
+    name: hashbrown
+    version: 0.15.5
+    sha: 9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1
+  - kind: registry
+    name: hashbrown
+    version: 0.16.1
+    sha: 841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100
+  - kind: registry
+    name: hecs
+    version: 0.10.5
+    sha: e1cbc675ee8d97b4d206a985137f8ad59666538f56f906474f554467a63c776d
+  - kind: registry
+    name: hecs-macros
+    version: 0.10.0
+    sha: 052fc25b12dc326082605cd2098eb76050a72fa0c0e9ea7faaa3f58b565fc970
+  - kind: registry
+    name: hermit-abi
+    version: 0.5.2
+    sha: fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c
+  - kind: registry
+    name: humantime
+    version: 2.3.0
+    sha: 135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424
+  - kind: registry
+    name: ident_case
+    version: 1.0.1
+    sha: b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39
+  - kind: registry
+    name: indexmap
+    version: 2.12.1
+    sha: 0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2
+  - kind: registry
+    name: is-terminal
+    version: 0.4.17
+    sha: 3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46
+  - kind: registry
+    name: itertools
+    version: 0.13.0
+    sha: 413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186
+  - kind: registry
+    name: itoa
+    version: 1.0.15
+    sha: 4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c
+  - kind: registry
+    name: libc
+    version: 0.2.177
+    sha: 2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976
+  - kind: registry
+    name: libloading
+    version: 0.8.9
+    sha: d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55
+  - kind: registry
+    name: linux-raw-sys
+    version: 0.11.0
+    sha: df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039
+  - kind: registry
+    name: log
+    version: 0.4.28
+    sha: 34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432
+  - kind: registry
+    name: memchr
+    version: 2.7.6
+    sha: f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273
+  - kind: registry
+    name: memmap2
+    version: 0.9.9
+    sha: 744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490
+  - kind: registry
+    name: minimal-lexical
+    version: 0.2.1
+    sha: 68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a
+  - kind: registry
+    name: miniz_oxide
+    version: 0.8.9
+    sha: 1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316
+  - kind: registry
+    name: nom
+    version: 7.1.3
+    sha: d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a
+  - kind: registry
+    name: num-conv
+    version: 0.1.0
+    sha: 51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9
+  - kind: registry
+    name: num_enum
+    version: 0.7.5
+    sha: b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c
+  - kind: registry
+    name: num_enum_derive
+    version: 0.7.5
+    sha: ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7
+  - kind: registry
+    name: num_threads
+    version: 0.1.7
+    sha: 5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9
+  - kind: registry
+    name: once_cell
+    version: 1.21.3
+    sha: 42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d
+  - kind: registry
+    name: owned_ttf_parser
+    version: 0.25.1
+    sha: 36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b
+  - kind: registry
+    name: pkg-config
+    version: 0.3.32
+    sha: 7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c
+  - kind: registry
+    name: png
+    version: 0.17.16
+    sha: 82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526
+  - kind: registry
+    name: powerfmt
+    version: 0.2.0
+    sha: 439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391
+  - kind: registry
+    name: pretty_env_logger
+    version: 0.5.0
+    sha: 865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c
+  - kind: registry
+    name: prettyplease
+    version: 0.2.37
+    sha: 479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b
+  - kind: registry
+    name: proc-macro-crate
+    version: 3.4.0
+    sha: 219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983
+  - kind: registry
+    name: proc-macro2
+    version: 1.0.103
+    sha: 5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8
+  - kind: registry
+    name: quick-xml
+    version: 0.30.0
+    sha: eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956
+  - kind: registry
+    name: quick-xml
+    version: 0.37.5
+    sha: 331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb
+  - kind: registry
+    name: quote
+    version: 1.0.42
+    sha: a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f
+  - kind: registry
+    name: regex
+    version: 1.12.2
+    sha: 843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4
+  - kind: registry
+    name: regex-automata
+    version: 0.4.13
+    sha: 5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c
+  - kind: registry
+    name: regex-syntax
+    version: 0.8.8
+    sha: 7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58
+  - kind: registry
+    name: rustc-hash
+    version: 2.1.1
+    sha: 357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d
+  - kind: registry
+    name: rustix
+    version: 1.1.2
+    sha: cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e
+  - kind: registry
+    name: rustversion
+    version: 1.0.22
+    sha: b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d
+  - kind: registry
+    name: sd-notify
+    version: 0.4.5
+    sha: b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4
+  - kind: registry
+    name: serde
+    version: 1.0.228
+    sha: 9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e
+  - kind: registry
+    name: serde_core
+    version: 1.0.228
+    sha: 41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad
+  - kind: registry
+    name: serde_derive
+    version: 1.0.228
+    sha: d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79
+  - kind: registry
+    name: shlex
+    version: 1.3.0
+    sha: 0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64
+  - kind: registry
+    name: simd-adler32
+    version: 0.3.7
+    sha: d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe
+  - kind: registry
+    name: smallvec
+    version: 1.15.1
+    sha: 67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03
+  - kind: registry
+    name: smithay-client-toolkit
+    version: 0.20.0
+    sha: 0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0
+  - kind: registry
+    name: spin
+    version: 0.9.8
+    sha: 6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
+  - kind: registry
+    name: strict-num
+    version: 0.1.1
+    sha: 6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731
+  - kind: registry
+    name: strsim
+    version: 0.11.1
+    sha: 7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f
+  - kind: registry
+    name: syn
+    version: 2.0.111
+    sha: 390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87
+  - kind: registry
+    name: termcolor
+    version: 1.4.1
+    sha: 06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755
+  - kind: registry
+    name: thiserror
+    version: 2.0.17
+    sha: f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8
+  - kind: registry
+    name: thiserror-impl
+    version: 2.0.17
+    sha: 3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913
+  - kind: registry
+    name: time
+    version: 0.3.44
+    sha: 91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d
+  - kind: registry
+    name: time-core
+    version: 0.1.6
+    sha: 40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b
+  - kind: registry
+    name: time-macros
+    version: 0.2.24
+    sha: 30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3
+  - kind: registry
+    name: tiny-skia
+    version: 0.11.4
+    sha: 83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab
+  - kind: registry
+    name: tiny-skia-path
+    version: 0.11.4
+    sha: 9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93
+  - kind: registry
+    name: toml_datetime
+    version: 0.7.3
+    sha: f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533
+  - kind: registry
+    name: toml_edit
+    version: 0.23.7
+    sha: 6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d
+  - kind: registry
+    name: toml_parser
+    version: 1.0.4
+    sha: c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e
+  - kind: registry
+    name: ttf-parser
+    version: 0.21.1
+    sha: 2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8
+  - kind: registry
+    name: ttf-parser
+    version: 0.25.1
+    sha: d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31
+  - kind: registry
+    name: unicode-ident
+    version: 1.0.22
+    sha: 9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5
+  - kind: registry
+    name: vergen
+    version: 9.0.6
+    sha: 6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777
+  - kind: registry
+    name: vergen-gitcl
+    version: 1.0.8
+    sha: b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe
+  - kind: registry
+    name: vergen-lib
+    version: 0.1.6
+    sha: 9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166
+  - kind: registry
+    name: version_check
+    version: 0.9.5
+    sha: 0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a
+  - kind: registry
+    name: wayland-backend
+    version: 0.3.11
+    sha: 673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35
+  - kind: registry
+    name: wayland-client
+    version: 0.31.11
+    sha: c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d
+  - kind: registry
+    name: wayland-csd-frame
+    version: 0.3.0
+    sha: 625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e
+  - kind: registry
+    name: wayland-cursor
+    version: 0.31.11
+    sha: 447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29
+  - kind: registry
+    name: wayland-protocols
+    version: 0.32.9
+    sha: efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901
+  - kind: registry
+    name: wayland-protocols-experimental
+    version: 20250721.0.1
+    sha: 40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1
+  - kind: registry
+    name: wayland-protocols-misc
+    version: 0.3.9
+    sha: 2dfe33d551eb8bffd03ff067a8b44bb963919157841a99957151299a6307d19c
+  - kind: registry
+    name: wayland-protocols-wlr
+    version: 0.3.9
+    sha: efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec
+  - kind: registry
+    name: wayland-scanner
+    version: 0.31.7
+    sha: 54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3
+  - kind: registry
+    name: wayland-server
+    version: 0.31.10
+    sha: fcbd4f3aba6c9fba70445ad2a484c0ef0356c1a9459b1e8e435bedc1971a6222
+  - kind: registry
+    name: wayland-sys
+    version: 0.31.7
+    sha: 34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142
+  - kind: registry
+    name: winapi-util
+    version: 0.1.11
+    sha: c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22
+  - kind: registry
+    name: windows-link
+    version: 0.2.1
+    sha: f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5
+  - kind: registry
+    name: windows-sys
+    version: 0.61.2
+    sha: ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc
+  - kind: registry
+    name: winnow
+    version: 0.7.14
+    sha: 5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829
+  - kind: registry
+    name: xcb
+    version: 1.7.0
+    sha: ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6
+  - kind: registry
+    name: xcb-util-cursor
+    version: 0.4.0
+    sha: c256d10270e6789ebbed752ec17fcf98a04363dc97aa9b7b92ab1af3a7bc5744
+  - kind: registry
+    name: xcb-util-cursor-sys
+    version: 0.2.0
+    sha: 8346f6cad5cb6b38645c53431ffe35bd0634e8154f529fa9d3f5f762c03c98b6
+  - kind: registry
+    name: xcursor
+    version: 0.3.10
+    sha: bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b
+  - kind: registry
+    name: xkeysym
+    version: 0.2.1
+    sha: b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56
+  - kind: registry
+    name: yeslogic-fontconfig-sys
+    version: 6.0.0
+    sha: 503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd
+  - kind: registry
+    name: zerocopy
+    version: 0.8.31
+    sha: fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3
+  - kind: registry
+    name: zerocopy-derive
+    version: 0.8.31
+    sha: d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a

--- a/elements/gamerslop/gamescope.bst
+++ b/elements/gamerslop/gamescope.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:OpenGamingCollective/gamescope.git
   track: ogc
-  ref: 3.16.19-159-g55ac921a1afb346696b6f80541741d431b3eba29
+  ref: 3.16.19-173-g13e1dd1984f90c9f8e79ffdc98a8abfdc25455ca
 # meson subprojects
 - kind: git_repo
   directory: subprojects/glm

--- a/elements/gamerslop/linux-ogc.bst
+++ b/elements/gamerslop/linux-ogc.bst
@@ -8,14 +8,14 @@ sources:
   track: "v*-ogc*"
   exclude:
   - "*-rc*"
-  ref: v7.2.1-ogc2-0-gca1f6f7168c7dc545c7053656fc6bd5fff97d816
+  ref: v7.2.1-ogc3-0-gcd7f77866692d61d59a931c9a9fa706f2cb88535
 - kind: git_repo
   directory: ogc-kernel-packages
   url: github:OpenGamingCollective/kernel-packages.git
   track: "v*-ogc*"
   exclude:
   - "*-rc*"
-  ref: v7.2.1-ogc2-0-g50d51ea084372ecbc4b89722aed81a0946f97bf5
+  ref: v7.2.1-ogc3-0-g68c3daa93e4b1e41918001028d48b6b167ad0a80
 - kind: git_repo
   directory: archlinux-kernel-config
   url: archlinux_gitlab:archlinux/packaging/packages/linux

--- a/elements/gamerslop/linux-ogc.bst
+++ b/elements/gamerslop/linux-ogc.bst
@@ -8,14 +8,14 @@ sources:
   track: "v*-ogc*"
   exclude:
   - "*-rc*"
-  ref: v7.2.1-ogc3-0-gcd7f77866692d61d59a931c9a9fa706f2cb88535
+  ref: v7.2.1-ogc5-0-gc4b5b14a460d9ea1fc07515391e2e1bae940c25f
 - kind: git_repo
   directory: ogc-kernel-packages
   url: github:OpenGamingCollective/kernel-packages.git
   track: "v*-ogc*"
   exclude:
   - "*-rc*"
-  ref: v7.2.1-ogc3-0-g68c3daa93e4b1e41918001028d48b6b167ad0a80
+  ref: v7.2.1-ogc5-0-g5fc47f707b518566b41258942a0a5a7a04d532f7
 - kind: git_repo
   directory: archlinux-kernel-config
   url: archlinux_gitlab:archlinux/packaging/packages/linux

--- a/elements/stacks/desktop.bst
+++ b/elements/stacks/desktop.bst
@@ -26,7 +26,7 @@ depends:
   - gnome-build-meta.bst:gnomeos-deps/alsa-ucm-conf.bst
   - gnome-build-meta.bst:gnomeos-deps/wl-clipboard.bst
   - gnome-build-meta.bst:gnomeos-deps/fprintd.bst
-  - gnome-build-meta.bst:sdk/xwayland-satellite.bst
+  - desktop/xwayland-satellite.bst
   - gnome-build-meta.bst:core-deps/speech-dispatcher.bst
   - gnome-build-meta.bst:core-deps/xdg-desktop-portal-gnome.bst
   - gnome-build-meta.bst:core-deps/xdg-desktop-portal-gtk.bst

--- a/elements/stacks/jackrabbit.bst
+++ b/elements/stacks/jackrabbit.bst
@@ -7,6 +7,7 @@ depends:
   - gamerslop/gamescope.bst
   - gamerslop/gamescope-session.bst
   - gamerslop/gamescope-session-steam.bst
+  - gamerslop/inputplumber.bst
   - gamerslop/mangohud.bst
   - gamerslop/powerbuttond.bst
   - gamerslop/powerstation.bst

--- a/elements/zirconium/common.bst
+++ b/elements/zirconium/common.bst
@@ -11,7 +11,7 @@ sources:
 - kind: git_repo
   url: github:zirconium-dev/zirconium.git
   track: main
-  ref: c04dc6c48b98381cb522b5f366c778e27dfaedfe
+  ref: 1df8e4ddcd7297ca5970957f50d343a73d862062
 
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst

--- a/project.conf
+++ b/project.conf
@@ -95,6 +95,7 @@ plugins:
   - origin: junction
     junction: plugins/buildstream-plugins-community.bst
     elements:
+      - cargo
       - collect_manifest
       - flatpak_image
       - flatpak_repo


### PR DESCRIPTION
Important fixes here, so one last stable update before 26.08.

Updates:
foot 1.27.0 -> 1.28.0
linux-ogc 7.2.1-ogc2 -> 7.2.1-ogc5

Changes:
Downgrade xwayland-satellite to 0.8.1 (working around [this issue](https://github.com/Supreeeme/xwayland-satellite/issues/468))
Actually install InputPlumber in Jackrabbit (it wasn't included in the jackrabbit stack, whoops...)